### PR TITLE
Add identity API v3 support for os-interface

### DIFF
--- a/shaker/engine/config.py
+++ b/shaker/engine/config.py
@@ -130,6 +130,12 @@ OPENSTACK_OPTS = [
                default=utils.env('OS_REGION_NAME') or 'RegionOne',
                help='Authentication region name, defaults to '
                     'env[OS_REGION_NAME].'),
+    cfg.StrOpt('os-interface', metavar='<os-interface>',
+               default=utils.env('OS_INTERFACE'),
+               sample_default='',
+               help='Interface type. Valid options are public, '
+                    'admin and internal. defaults to '
+                    'env[OS_INTERFACE].'),
     cfg.StrOpt('os-profile', metavar='<hmac-key>',
                default=utils.env('OS_PROFILE'),
                sample_default='',

--- a/shaker/engine/utils.py
+++ b/shaker/engine/utils.py
@@ -278,6 +278,8 @@ def pack_openstack_params(conf):
         if value:
             params['auth'][attr] = value
 
+    if conf.os_interface:
+        params['os_interface'] = conf.os_interface
     if conf.os_identity_api_version:
         params['identity_api_version'] = conf.os_identity_api_version
     if conf.os_profile:

--- a/shaker/tests/test_server.py
+++ b/shaker/tests/test_server.py
@@ -175,6 +175,7 @@ class TestServerPlayScenario(testtools.TestCase):
         self.config_fixture.config(os_auth_url='auth-url')
         self.config_fixture.config(os_project_domain_name='Default')
         self.config_fixture.config(os_user_domain_name='Default')
+        self.config_fixture.config(os_interface='public')
         self.config_fixture.config(os_identity_api_version='3')
 
         deploy_obj.deploy.return_value = {
@@ -196,7 +197,7 @@ class TestServerPlayScenario(testtools.TestCase):
                       user_domain_name='Default'),
             identity_api_version='3',
             os_region_name='RegionOne',
-            os_cacert=None, os_insecure=False)
+            os_cacert=None, os_insecure=False, os_interface='public')
         deploy_obj.connect_to_openstack.assert_called_once_with(
             openstack_params, 'shaker-flavor', 'shaker-image', None,
             ['8.8.8.8', '8.8.4.4'])


### PR DESCRIPTION
At AT&T our Openstack Airship deployments use identify api v3 but
require the os-interface parameter to be passed in order to correctly
authenticate.

This commit adds support for specifying and using os-interface in Shaker